### PR TITLE
fix(BooleanField): add defaultChecked prop

### DIFF
--- a/packages/shadcn/src/components/ui/autoform/components/BooleanField.tsx
+++ b/packages/shadcn/src/components/ui/autoform/components/BooleanField.tsx
@@ -23,6 +23,7 @@ export const BooleanField: React.FC<AutoFormFieldProps> = ({
         inputProps.onChange(event);
       }}
       checked={inputProps.value}
+      defaultChecked={field.default}
     />
     <Label htmlFor={id}>
       {label}


### PR DESCRIPTION
This pull request includes a small change to the `BooleanField` component in the 
`packages/shadcn/src/components/ui/autoform/components/BooleanField.tsx` file. The change ensures that the checkbox is set to its default checked state based on the `field.default` value.

* `packages/shadcn/src/components/ui/autoform/components/BooleanField.tsx`: Added `defaultChecked` attribute to set the checkbox's default state based on `field.default`.